### PR TITLE
Support VSCode remote dev

### DIFF
--- a/src/contextmenu.js
+++ b/src/contextmenu.js
@@ -22,7 +22,12 @@ function getVscodeLink({
     repo, file, isFolder, line,
 }) {
     return getOptions()
-        .then(({ insidersBuild, remoteHost, basePath, debug }) => {
+        .then(({
+            insidersBuild,
+            remoteHost,
+            basePath, 
+            debug
+        }) => {
             let vscodeLink = insidersBuild
                 ? 'vscode-insiders'
                 : 'vscode';
@@ -30,7 +35,11 @@ function getVscodeLink({
             // vscode://vscode-remote/ssh-remote+[host]/[path/to/file]:[line]
             // OR
             // vscode://file/[path/to/file]:[line]
-            vscodeLink += (remoteHost != '') ? '://vscode-remote/ssh-remote+' + remoteHost : '://file';
+            if (remoteHost !== '') {
+                vscodeLink += `://vscode-remote/ssh-remote+${remoteHost}`;
+            } else {
+                vscodeLink += '://file';
+            }
 
             // windows paths don't start with slash
             if (basePath[0] !== '/') {
@@ -46,10 +55,10 @@ function getVscodeLink({
 
             if (line) {
                 vscodeLink += `:${line}:1`;
-            } else if (remoteHost != '') {
+            } else {
                 // vscode will open a new project without given a line number
-                // so has to at least go to first line here.
-                vscodeLink += `:0:1`;
+                // for remote project so has to at least go to first line here.
+                vscodeLink += ':0:1';
             }
 
             if (debug) {
@@ -66,7 +75,7 @@ function isPR(linkUrl) {
 
 function parseLink(linkUrl, selectionText, pageUrl) {
     return new Promise((resolve, reject) => {
-        const url = new URL(linkUrl ? linkUrl : pageUrl);
+        const url = new URL(linkUrl);
         const path = url.pathname;
 
         if (isPR(url.pathname)) {
@@ -124,6 +133,6 @@ function openInVscode({ linkUrl, selectionText, pageUrl }) {
 
 chrome.contextMenus.create({
     title: 'Open in VSCode',
-    contexts: ['link', 'page'],
+    contexts: ['link'],
     onclick: openInVscode,
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Open in VSCode",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Open Github and Gitlab links in VSCode",
     "page_action": {
         "default_icon": "icons/icon19.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "Open in VSCode",
-    "version": "1.2.0",
+    "version": "1.1.0",
     "description": "Open Github and Gitlab links in VSCode",
     "page_action": {
         "default_icon": "icons/icon19.png",

--- a/src/options.html
+++ b/src/options.html
@@ -32,6 +32,11 @@
             <h3>Settings</h3>
 
             <div class="form-group">
+                <label for="remoteHost">Remote Host</label>
+                <input type="text" class="form-control" id="remoteHost" aria-describedby="remoteHostHelp">
+                <small id="remoteHostHelp" class="form-text text-muted">Empty if local, o/w specify your hostname.</small>
+            </div>
+            <div class="form-group">
                 <label for="basePath">Base path</label>
                 <input type="text" class="form-control" id="basePath" aria-describedby="basePathHelp">
                 <small id="basePathHelp" class="form-text text-muted">Full path to where you keep all your repositories locally (eg. /Users/bob/git).</small>

--- a/src/options.js
+++ b/src/options.js
@@ -1,4 +1,5 @@
 const defaultOptions = {
+    remoteHost: '',
     basePath: '',
     insidersBuild: false,
     debug: false,
@@ -6,6 +7,7 @@ const defaultOptions = {
 
 function restoreOptions() {
     chrome.storage.sync.get(defaultOptions, (options) => {
+        document.getElementById('remoteHost').value = options.remoteHost;
         document.getElementById('basePath').value = options.basePath;
         document.getElementById('insidersBuild').checked = options.insidersBuild;
         document.getElementById('debug').checked = options.debug;
@@ -16,6 +18,7 @@ function saveOptions(event) {
     event.preventDefault();
 
     chrome.storage.sync.set({
+        remoteHost: document.getElementById('remoteHost').value,
         basePath: document.getElementById('basePath').value,
         insidersBuild: document.getElementById('insidersBuild').checked,
         debug: document.getElementById('debug').checked,


### PR DESCRIPTION
Allow user to work with ssh-remote mode in vscode.
User could set the "Remote Host" in Options to open file in vscode ssh-remote.

This also add the functionality to open file for current page/tab's URL.