### PR TITLE
adding option to support filepath including repo path (org/username)

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,11 +1,11 @@
 {
     "manifest_version": 3,
-    "name": "Open in VSCode",
-    "version": "1.4.0",
+    "name": "Open in VSCode (pmunin)",
+    "version": "1.4.1",
     "description": "Open Github and Gitlab links in VSCode",
     "action": {
         "default_icon": "icons/icon19.png",
-        "default_title": "Open in VSCode"
+        "default_title": "Open in VSCode (pmunin)"
     },
     "author": "Domenico Gemoli",
     "permissions": [

--- a/src/options.html
+++ b/src/options.html
@@ -37,6 +37,14 @@
                 <small id="basePathHelp" class="form-text text-muted"><b class="text-danger">Required!</b> Full path to a directory that contains all of your cloned repositories (eg. <code>/Users/bob/git</code>).</small>
             </div>
             <div class="form-group">
+                <label for="basePathFormat">Base path format</label>
+                <select type="radio" class="form-control" id="basePathFormat" aria-describedby="basePathFormatHelp">
+                    <option value="{basePath}/{repoName}">{basePath}/{repoName}</option>
+                    <option value="{basePath}/{repoPath}/{repoName}">{basePath}/{repoPath}/{repoName}</option>
+                </select>
+                <small id="basePathFormatHelp" class="form-text text-muted">Should local path include the repository's user/org name?</small>
+            </div>
+            <div class="form-group">
                 <label for="remoteHost">Remote Host</label>
                 <input type="text" class="form-control" id="remoteHost" aria-describedby="remoteHostHelp">
                 <small id="remoteHostHelp" class="form-text text-muted">Only necessary for <a href="https://code.visualstudio.com/docs/remote/remote-overview" target="_blank">Remote Development</a>. Leave empty if your repositories are on your local machine.</small>

--- a/src/options.js
+++ b/src/options.js
@@ -3,6 +3,7 @@
 const defaultOptions = {
     remoteHost: '',
     basePath: '',
+    basePathFormat: '{basePath}/{repoName}',
     insidersBuild: false,
     debug: false,
 };
@@ -11,6 +12,7 @@ function restoreOptions() {
     chrome.storage.sync.get(defaultOptions, (options) => {
         document.getElementById('remoteHost').value = options.remoteHost;
         document.getElementById('basePath').value = options.basePath;
+        document.getElementById('basePathFormat').value = options.basePathFormat;
         document.getElementById('insidersBuild').checked = options.insidersBuild;
         document.getElementById('debug').checked = options.debug;
     });
@@ -22,6 +24,7 @@ function saveOptions(event) {
     chrome.storage.sync.set({
         remoteHost: document.getElementById('remoteHost').value,
         basePath: document.getElementById('basePath').value,
+        basePathFormat: document.getElementById('basePathFormat').value,
         insidersBuild: document.getElementById('insidersBuild').checked,
         debug: document.getElementById('debug').checked,
     }, () => {


### PR DESCRIPTION
Adding option `basePathFormat` to support path to repo included in local path. E.g.:

> **basePath**: `/Users/bob/git`
> **repo url**: https://github.com/{userName}/{repoName}/.../{filePath}
> **vscode-link**: ... {basePath}/{userName}/{repoName}/{filePath}

Default option stays the current behavior ({basePath}/{repoName}).